### PR TITLE
Added webhook for basyx wiki readthedocs integration

### DIFF
--- a/otterdog/eclipse-basyx.jsonnet
+++ b/otterdog/eclipse-basyx.jsonnet
@@ -322,12 +322,7 @@ orgs.newOrg('eclipse-basyx') {
             "pull_request",
             "push"
           ],
-          secret: "********",
-        },
-      ],
-      secrets: [
-        orgs.newRepoSecret('READTHEDOCS_WIKI_TOKEN') {
-          value: "********",
+          secret: "pass:bots/dt.basyx/readthedocs.org/wiki-webhook-secret",
         },
       ],
     },

--- a/otterdog/eclipse-basyx.jsonnet
+++ b/otterdog/eclipse-basyx.jsonnet
@@ -313,6 +313,23 @@ orgs.newOrg('eclipse-basyx') {
       workflows+: {
         enabled: false,
       },
+      webhooks+: [
+        orgs.newRepoWebhook('https://readthedocs.org/api/v2/webhook/basyx-wiki/253837/') {
+          content_type: "json",
+          events+: [
+            "create",
+            "delete",
+            "pull_request",
+            "push"
+          ],
+          secret: "********",
+          secrets: [
+            orgs.newRepoSecret('READTHEDOCS_WIKI_TOKEN') {
+              value: "********",
+            },
+          ],
+        },
+      ],
     },
   ],
 }

--- a/otterdog/eclipse-basyx.jsonnet
+++ b/otterdog/eclipse-basyx.jsonnet
@@ -313,7 +313,7 @@ orgs.newOrg('eclipse-basyx') {
       workflows+: {
         enabled: false,
       },
-      webhooks+: [
+      webhooks: [
         orgs.newRepoWebhook('https://readthedocs.org/api/v2/webhook/basyx-wiki/253837/') {
           content_type: "json",
           events+: [
@@ -323,11 +323,11 @@ orgs.newOrg('eclipse-basyx') {
             "push"
           ],
           secret: "********",
-          secrets: [
-            orgs.newRepoSecret('READTHEDOCS_WIKI_TOKEN') {
-              value: "********",
-            },
-          ],
+        },
+      ],
+      secrets: [
+        orgs.newRepoSecret('READTHEDOCS_WIKI_TOKEN') {
+          value: "********",
         },
       ],
     },


### PR DESCRIPTION
I added a webhook to the BaSyx Wiki Repo to integrate readthedocs. I also had to enter a secret here which I of course can't enter in clear text. I'm unfamiliar with the workflow for creating repo-level secrets with otterdog. Please mail me (Aaron.Zielstorff@htw-berlin.de) to get the secret for readthedocs to finalize the PR.