### PR TITLE
Adds new repository for BaSyx AAS Web UI

### DIFF
--- a/otterdog/eclipse-basyx.jsonnet
+++ b/otterdog/eclipse-basyx.jsonnet
@@ -46,6 +46,23 @@ orgs.newOrg('eclipse-basyx') {
         default_workflow_permissions: "write",
       },
     },
+    orgs.newRepo('basyx-aas-web-ui') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      description: "Web-based user interface for managing and interacting with Asset Administration Shells (AAS)",
+      topics+: [
+        "basyx",
+        "aas",
+        "assetadministrationshell",
+        "web-ui",
+        "vue"
+      ],
+      web_commit_signoff_required: false,
+      workflows+: {
+        default_workflow_permissions: "read",
+      },
+    },
     orgs.newRepo('basyx-archive') {
       archived: true,
       description: "Archived single repo",


### PR DESCRIPTION
We've decided to move the BaSyx AAS Web UI into it's own repository. Over the last few years it had grown considerably in size and got a lot of attention as well as pulls from dockerhub. In order to separate it from the rest of the BaSyx applications and to improve development productivity, moving it to it's own repository seems to be beneficial.