### PR TITLE
Add `basyx-pdf-to-aas` repository

### DIFF
--- a/otterdog/eclipse-basyx.jsonnet
+++ b/otterdog/eclipse-basyx.jsonnet
@@ -257,6 +257,23 @@ orgs.newOrg('eclipse-basyx') {
         default_workflow_permissions: "write",
       },
     },
+    orgs.newRepo('basyx-pdf-to-aas') {
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      web_commit_signoff_required: false,
+      description: "Python library to extract technical data via LLMs from PDF and export them in AAS format.",
+      topics+: [
+        "basyx",
+        "aas",
+        "asset-administration-shell",
+        "large-language-model",
+        "technical-data-extraction"
+      ],
+      workflows+: {
+        default_workflow_permissions: "write",
+      },
+    },
     orgs.newRepo('basyx-website') {
       allow_merge_commit: true,
       allow_update_branch: false,


### PR DESCRIPTION
We created a python library and scripts to extract technical data from PDF (typically data sheets) or texts via LLMs. The results can be exported as Asset Administration Shell, especially filling the Technical Data submodel, utilizing the basyx-python-sdk. The library should be published in eclipse-basyx as it was developed in context of BaSys4Transfer and uses basyx technologies under the hood.

The python module is named pdf2aas. We could discuss wether the repo title `basyx-pdf-to-aas` is to generic, as the library is focused on technical data and the technical data submodel respectively.