### PR TITLE
fix: disallow merge commits on charts repo

### DIFF
--- a/otterdog/eclipse-basyx.jsonnet
+++ b/otterdog/eclipse-basyx.jsonnet
@@ -364,7 +364,7 @@ orgs.newOrg('dt.basyx', 'eclipse-basyx') {
       ],
     },
     orgs.newRepo('charts') {
-      allow_merge_commit: true,
+      allow_merge_commit: false,
       allow_update_branch: false,
       delete_branch_on_merge: false,
       description: "This repository contains Helm charts for Eclipse BaSyx",


### PR DESCRIPTION
There were a couple of instances where the person authoring a PR was assuming for the PR to be squashed on merge but the merge was executed as separate commit. The problem is that non-conventional commits were added to main. 

This config still enables rebase merge - thus not solving the issue entirely but narrowing down the options for reviewers.