### PR TITLE
Populate the "About" section of the BaSyx-Python SDK

### DIFF
--- a/otterdog/eclipse-basyx.jsonnet
+++ b/otterdog/eclipse-basyx.jsonnet
@@ -303,6 +303,12 @@ orgs.newOrg('dt.basyx', 'eclipse-basyx') {
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,
+      description: "The Eclipse BaSyx Python SDK, an implementation of the Asset Administration Shell (AAS) for Industry 4.0 systems",
+      topics+: [
+        "basyx",
+        "aas",
+        "assetadministrationshell",
+      ],
       web_commit_signoff_required: false,
       has_discussions: true,
       workflows+: {


### PR DESCRIPTION
Previously, the `basyx-python-sdk` repository did not have an `About` section. 
This adds it.

Fixes [basyx-python-sdk#472](https://github.com/eclipse-basyx/basyx-python-sdk/issues/472)