### PR TITLE
Fix `About` section in wrong repo

### DIFF
--- a/otterdog/eclipse-basyx.jsonnet
+++ b/otterdog/eclipse-basyx.jsonnet
@@ -303,12 +303,6 @@ orgs.newOrg('dt.basyx', 'eclipse-basyx') {
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,
-      description: "The Eclipse BaSyx Python SDK, an implementation of the Asset Administration Shell (AAS) for Industry 4.0 systems",
-      topics+: [
-        "basyx",
-        "aas",
-        "assetadministrationshell",
-      ],
       web_commit_signoff_required: false,
       has_discussions: true,
       workflows+: {

--- a/otterdog/eclipse-basyx.jsonnet
+++ b/otterdog/eclipse-basyx.jsonnet
@@ -303,6 +303,12 @@ orgs.newOrg('dt.basyx', 'eclipse-basyx') {
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,
+      description: "The Eclipse BaSyx Python SDK, an implementation of the Asset Administration Shell (AAS) for Industry 4.0 systems",
+      topics+: [
+        "basyx",
+        "aas",
+        "assetadministrationshell",
+      ],
       web_commit_signoff_required: false,
       has_discussions: true,
       workflows+: {

--- a/otterdog/eclipse-basyx.jsonnet
+++ b/otterdog/eclipse-basyx.jsonnet
@@ -303,12 +303,6 @@ orgs.newOrg('dt.basyx', 'eclipse-basyx') {
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,
-      description: "The Eclipse BaSyx Python SDK, an implementation of the Asset Administration Shell (AAS) for Industry 4.0 systems",
-      topics+: [
-        "basyx",
-        "aas",
-        "assetadministrationshell",
-      ],
       web_commit_signoff_required: false,
       has_discussions: true,
       workflows+: {
@@ -320,6 +314,12 @@ orgs.newOrg('dt.basyx', 'eclipse-basyx') {
       allow_update_branch: false,
       delete_branch_on_merge: false,
       web_commit_signoff_required: false,
+      description: "The Eclipse BaSyx Python SDK, an implementation of the Asset Administration Shell (AAS) for Industry 4.0 systems",
+      topics+: [
+        "basyx",
+        "aas",
+        "assetadministrationshell",
+      ],
       workflows+: {
         default_workflow_permissions: "write",
       },


### PR DESCRIPTION
The previous PR #16 placed the `description` and `topics` fields in
the wrong repository entry in `eclipse-basyx.jsonnet`. They were
added to the repo above `basyx-python-sdk` instead of
`basyx-python-sdk` itself.

This moves them to the correct repository entry.
